### PR TITLE
[CI] Build/publish wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd#
+
+name: Build Wheels
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  # Shared with `deploy-pypi`.
+  group: wheel-${{ github.ref }}
+  # Cancel any in-progress build or publish.
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheel
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
+      - name: Build wheels
+        run: pip wheel --no-deps --wheel-dir wheelhouse .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openassetio-traitgen-wheels
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+name: Deploy PyPI
+
+concurrency:
+  # Shared with `build-wheels`.
+  group: wheel-${{ github.ref }}
+  # Allow `build-wheels` to finish.
+  cancel-in-progress: false
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  publish_testpypi:
+    name: Publish distribution 📦 to TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-traitgen-wheels
+          path: dist
+
+      - name: Upload to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_ACCESS_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  publish_pypi:
+    name: Publish distribution 📦 to PyPI
+    needs: publish_testpypi
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-traitgen-wheels
+          path: dist
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Specification classes from a simple YAML description. This avoids
 the laborious and error-prone task of creating these by hand.
 
 This package is entirely self-contained and can be used without an
-`openassetio` installation. It provides code generation CLI, along with
-a corresponding python package that can be used for custom generation.
+[OpenAssetIO](https://github.com/OpenAssetIO/OpenAssetIO)
+installation. It provides code generation CLI, along with a
+corresponding python package that can be used for custom generation.
 
 ## Supported languages
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ corresponding python package that can be used for custom generation.
 
 ## Installation
 
+The package is available on PyPI, so to get the latest stable release
+```bash
+python -m pip install openassetio-traitgen
+```
+
+For the bleeding edge, the package can also be installed after cloning
+this repository using
+
 ```bash
 python -m pip install .
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ openassetio-traitgen -h
 
 ## Development notes
 
-This package follows the main [OpenAssetIO contribution process](../../contributing/PROCESS.md).
+This package follows the main
+[OpenAssetIO contribution process](https://github.com/OpenAssetIO/OpenAssetIO/blob/main/contributing/PROCESS.md).
 
 However, as a pure Python project, it adheres to strict PEP-8 naming
 conventions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+# The metadata here should be kept in sync with the main OpenAssetIO
+# repository (Python versions, platforms, etc): https://github.com/OpenAssetIO/OpenAssetIO
+
+[build-system]
+requires = [
+    "setuptools>=65.5.0"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openassetio-traitgen"
+version = "1.0.0a3"
+requires-python = ">=3.7"
+
+authors = [
+    { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }
+]
+description = """\
+    Generate OpenAssetIO Trait and Specification classes from a simple YAML description.\
+    """
+keywords = ["openassetio", "codegen", "trait"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Build Tools",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Code Generators"
+]
+
+[project.readme]
+text = """\
+# OpenAssetIO Code Generation Tool
+
+The `openassetio-traitgen` tool can be used to generate Trait and
+Specification classes from a simple YAML description. This avoids
+the laborious and error-prone task of creating these by hand.
+
+This package is entirely self-contained and can be used without an
+[OpenAssetIO](https://github.com/OpenAssetIO/OpenAssetIO)
+installation. It provides code generation CLI, along with a
+corresponding python package that can be used for custom generation.
+
+## Supported languages
+
+- Python 3.7+
+
+## Installation
+
+The package is available on PyPI, so to get the latest stable release
+```bash
+python -m pip install openassetio-traitgen
+```
+
+## Usage
+
+```bash
+openassetio-traitgen -h
+```
+"""
+content-type = "text/markdown"
+
+[project.urls]
+OpenAssetIO = "https://github.com/OpenAssetIO/OpenAssetIO"
+Source = "https://github.com/OpenAssetIO/OpenAssetIO-TraitGen"
+Issues = "https://github.com/OpenAssetIO/OpenAssetIO-TraitGen/issues"
+
 # NB: This requires the use of pyproject-flake8
 [tool.flake8]
 max-line-length = 99


### PR DESCRIPTION
Closes #2. This will allow dependent projects such as https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation to automate its use as part of their build pipeline.

Build wheels on PR or and merge to `main`. Publish wheels built on `main` for release. Waiting for wheels to be built before publishing, if not already (see `concurrency.group` in the `.yml` files).
