### PR TITLE
[Docs] Add release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,10 @@
+Release Notes
+=============
+
+v1.0.0-alpha.3
+--------------
+
+### New Features
+
+- Initial release. Branched from OpenAssetIO project from
+ [this point forward](https://github.com/OpenAssetIO/OpenAssetIO/commit/a5a393178b522121e1afe2fdac4da1f4c81ac9d4).


### PR DESCRIPTION
Add release notes document to the traitgen project, as it's its own thing now and needs them.
Neglected to do this before publishing the initial pypi release, but I don't think it matters.