### PR TITLE
[Release] Bump version to alpha 1.0.4-alpha-4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.x
+v1.0.0-alpha.4
 
 ### Breaking Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-traitgen"
-version = "1.0.0a3"
+version = "1.0.0a4"
 requires-python = ">=3.7"
 
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,9 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="openassetio-traitgen",
-    version="1.0.0-alpha.1",
     packages=find_packages(where="python"),
     package_dir={"": "python"},
     include_package_data=True,
-    python_requires=">=3.7",
     install_requires=["jinja2==3.1.2", "pyyaml==5.4.1", "jsonschema==4.7.2"],
     entry_points={
         "console_scripts": ["openassetio-traitgen=openassetio_traitgen.__main__:main"],


### PR DESCRIPTION
This dosen't really need two reviewers, just maximising my chances of getting this in early tommorow :P Whoever gets there first, thanks a bundle :)

Bump traitgen version to alpha 4 in anticipation of imminent release, so mediacreation can use the new direct module generation mode.

Saw that `setup.py` had a few duplicate declarations that were also declared in `pyproject.toml`.
I didn't really want to touch it, but it seemed somewhat sketchy to have these duplicated, the version was even wrong.
`pyproject.toml` _does_ takes precedence anyway, so maybe there was no need to do this at all, but I dunno, seemed pretty open to confusion when updating version numbers.
The rest of `setup.py` is fine, no need to move it and add the churn.

Since this did technically touch the versioning mechanism in a way outside our release process (barely), did a testpypi dev push just to be sure nothing breaks : https://test.pypi.org/project/openassetio-traitgen/1.0.0a4.dev0/