### PR TITLE
[CI] Run `ctest` tests for C++ generated code

### DIFF
--- a/.github/build_openassetio/action.yml
+++ b/.github/build_openassetio/action.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The Foundry Visionmongers Ltd
+
+# Composite action for reuse within other workflows.
+# Builds OpenAssetIO.
+# Should be run on a ghcr.io/openassetio/openassetio-build container.
+
+name: Build OpenAssetIO
+description: Builds OpenAssetIO and publishes an artifact
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout OpenAssetIO
+      uses: actions/checkout@v3
+      with:
+        repository: OpenAssetIO/OpenAssetIO
+        path: openassetio-checkout
+
+    - name: Build OpenAssetIO
+      shell: bash
+      run: |
+        cd openassetio-checkout
+        mkdir build
+        cmake -G Ninja -S . -B build
+        cmake --build build
+        cmake --install build
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: OpenAssetIO Build
+        path: openassetio-checkout/build/dist
+        retention-days: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,44 @@ jobs:
           python -m pip install .
       - name: Test
         run: python -m pytest -v -m "not ctest"
+
+  build-openassetio:
+    name: Build OpenAssetIO
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openassetio/openassetio-build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/build_openassetio
+
+  ctest:
+    name: C++ tests
+    runs-on: ubuntu-latest
+    needs: build-openassetio
+    container:
+      image: aswf/ci-vfxall:2022-clang14.3
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get OpenAssetIO
+        uses: actions/download-artifact@v3
+        with:
+          name: OpenAssetIO Build
+          path: ${{ github.workspace }}/openassetio
+
+      - name: Install ctest dependencies
+        run: >
+          python -m pip install
+          -r tests/requirements.txt
+          -r tests/ctest-requirements.txt
+          .
+
+      - name: Test
+        run: python -m pytest -v -m ctest
+        env:
+          CMAKE_PREFIX_PATH: ${{ github.workspace }}/openassetio
+          # TODO(DF): Sanitizers disabled due to lack of support in ASWF
+          # Docker image. Re-enable once per-platform builds enabled
+          # (i.e. once OpenAssetIO Conan package is available).
+          OPENASSETIO_TRAITGENTEST_CMAKE_PRESET: ci

--- a/tests/generators/cpp/CMakePresets.json
+++ b/tests/generators/cpp/CMakePresets.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "ci",
+      "inherits": "lint",
+      "description": "TODO(DF): Sanitizers disabled due to ASWF Docker image. Re-enable once using Conan instead",
+      "cacheVariables": {
+        "OPENASSETIO_TRAITGENTEST_ENABLE_SANITIZER_ADDRESS": "OFF",
+        "OPENASSETIO_TRAITGENTEST_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR": "OFF"
+      }
+    },
+    {
       "name": "test",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",


### PR DESCRIPTION
Builds on #12. Closes #17. Run the `pytest` tests marked with "ctest", which involves building and executing a CMake CTest test suite.

Use an OpenAssetIO build action, to be replaced in the future with a Conan package, once available.

Avoid cross-platform issues, for now, by only building/testing on the ASWF Docker image. Once the Conan package is available, this can be converted to a per platform build matrix.

The ASWF Docker image's GCC does not support sanitizers, so disable on CI for now.