### PR TITLE
Bump version to 1.0.0-alpha.6

### DIFF
--- a/.github/build_openassetio/action.yml
+++ b/.github/build_openassetio/action.yml
@@ -15,6 +15,9 @@ runs:
       with:
         repository: OpenAssetIO/OpenAssetIO
         path: openassetio-checkout
+        # Pin to ensure compatibility with the current release until
+        # alpha.11 is release with API removals.
+        ref: v1.0.0-alpha.10
 
     - name: Build OpenAssetIO
       shell: bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.X
+v1.0.0-alpha.6
 --------------
 
 ### Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-traitgen"
-version = "1.0.0a5"
+version = "1.0.0a6"
 requires-python = ">=3.7"
 
 authors = [


### PR DESCRIPTION
This pins OpenAssetIO CI to a10, so we can make sure it is compatible with the current release version.