### PR TITLE
[CI] Un-pin OpenAssetIO version

### DIFF
--- a/.github/build_openassetio/action.yml
+++ b/.github/build_openassetio/action.yml
@@ -15,9 +15,6 @@ runs:
       with:
         repository: OpenAssetIO/OpenAssetIO
         path: openassetio-checkout
-        # Pin to ensure compatibility with the current release until
-        # alpha.11 is release with API removals.
-        ref: v1.0.0-alpha.10
 
     - name: Build OpenAssetIO
       shell: bash


### PR DESCRIPTION
Whilst this re-instates the inconsistency between python and c++ tests, it avoids us accidentally leaving C++ behind, untill we have some other more suitable way to get vLatest.