### PR TITLE
Fix tests now missing traits do not error

### DIFF
--- a/tests/generators/cpp/src/test.cpp
+++ b/tests/generators/cpp/src/test.cpp
@@ -369,16 +369,15 @@ TEMPLATE_TEST_CASE("Property getters", "", openassetio_abi::Bool, openassetio_ab
 
     WHEN("property is queried without a default") {
       THEN("exception is thrown") {
-        // TODO(DF): better deterministic exception message.
-        CHECK_THROWS_AS(fixture.getProperty(), std::out_of_range);
+        CHECK_THROWS_MATCHES(fixture.getProperty(), std::runtime_error,
+                             Catch::Matchers::Message("Property is not set."));
       }
     }
 
     WHEN("property is queried with a default") {
-      THEN("exception is thrown") {
-        // TODO(DF): better deterministic exception message.
-        CHECK_THROWS_AS(fixture.getProperty(Fixture::kDefaultValue), std::out_of_range);
-      }
+      const PropertyType value = fixture.getProperty(Fixture::kDefaultValue);
+
+      THEN("default is returned") { CHECK(value == Fixture::kDefaultValue); }
     }
   }
 


### PR DESCRIPTION
Closes #48

In OpenAssetIO/OpenAssetIO#970 `TraitsData::getTraitProperty` was updated such that an exception is no longer thrown when attempting to retrieve a property of trait that is not imbued in the data.

This means the behaviour of the TraitGen view classes is now as intended, finally.

So update the tests to reflect this.