### PR TITLE
[CI] Retarget to OpenAssetIO v1.0.0-beta.1.0

### DIFF
--- a/.github/build_openassetio/action.yml
+++ b/.github/build_openassetio/action.yml
@@ -15,6 +15,7 @@ runs:
       with:
         repository: OpenAssetIO/OpenAssetIO
         path: openassetio-checkout
+        ref: v1.0.0-beta.1.0
 
     - name: Build OpenAssetIO
       shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,19 +20,12 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Download wheels from commit OpenAssetIO main
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: build-wheels.yml
-          workflow_conclusion: success
-          name: openassetio-wheels
-          repo: OpenAssetIO/OpenAssetIO
-          path: deps
-
       - name: Install dependencies
+        # Pin openassetio to match C++ version, since
+        # tests/requirements.txt specifies a range. Also see
+        # build_openassetio action.
         run: |
-          # Use wheels from feature branch for intermediate testing
-          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
+          python -m pip install openassetio==1.0.0b1.rev0
           python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,29 +17,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Constrain to single version to simplify install from wheels
-        os: ['ubuntu-latest']
-        python: ['3.7']
-        # os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
-        # python: ['3.7', '3.9', '3.10']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        python: ['3.7', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
-
-      - name: Download wheels from OpenAssetIO main
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: build-wheels.yml
-          workflow_conclusion: success
-          name: openassetio-wheels
-          repo: OpenAssetIO/OpenAssetIO
-          path: deps
-
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+      # Pin openassetio to match C++ version, since
+      # tests/requirements.txt specifies a range. Also see
+      # build_openassetio action.
       - run: |
-          # Use wheels from feature branch for intermediate testing
-          python -m pip install ./deps/openassetio-*cp37*-manylinux_*_x86_64.whl
+          python -m pip install openassetio==1.0.0b1.rev0
           python -m pip install -r tests/requirements.txt
           python -m pip install .
       - name: Test

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,7 @@ pylint==2.15.5  # Guard against warn/error changes
 jsonschema==4.7.2
 tree-sitter==0.20.1  # For parsing C++ AST to assert on comment text.
 tree-sitter-languages==1.5.0
-#openassetio>=1.0.0b1
+# Do not pin openassetio to a specific version, so that pip will not
+# complain when testing against future openassetio versions (e.g.
+# OpenAssetIO integration test CI).
+openassetio>=1.0.0b1.rev0


### PR DESCRIPTION
Including CTest tests against release tag, rather than `main`.