### PR TITLE
[CI] Test with x86 MacOS GitHub runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-13']
         python: ['3.7', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub has updated `macos-latest` to be an ARM based runner. Until we have ARM wheels for OpenAssetIO, we must pin to an x86 MacOS runner, or tests will fail at the `pip install` phase.