### PR TITLE
Default to CY24 and drop support for CY22 and below

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build_wheels:
     name: Build wheel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Pylint
     steps:
       - uses: actions/checkout@v3
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         # Pin openassetio to match C++ version, since
@@ -39,7 +39,7 @@ jobs:
             tests
 
   black:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Python formatting
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -57,7 +57,7 @@ jobs:
         run: black --diff --check .
 
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   publish_testpypi:
     name: Publish distribution 📦 to TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v3
@@ -38,7 +38,7 @@ jobs:
   publish_pypi:
     name: Publish distribution 📦 to PyPI
     needs: publish_testpypi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-13']
-        python: ['3.7', '3.9', '3.10']
+        os: ['windows-2022', 'ubuntu-22.04', 'macos-13']
+        python: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -36,7 +36,7 @@ jobs:
 
   build-openassetio:
     name: Build OpenAssetIO
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/openassetio/openassetio-build
     steps:
@@ -46,10 +46,10 @@ jobs:
 
   ctest:
     name: C++ tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-openassetio
     container:
-      image: aswf/ci-vfxall:2022-clang14.3
+      image: aswf/ci-base:2024
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ corresponding python package that can be used for custom generation.
 
 ## Supported languages
 
-- Python 3.7+
+- Python 3.10+
 - C++ 17+
 
 ## Installation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Breaking changes
+
+- Removed support for VFX Reference Platform CY22 or lower and added
+  support for CY24. This means Python 3.7 and 3.9 builds are no longer
+  tested or published, whereas Python 3.11 is now published.
+  [OpenAssetIO#1351](https://github.com/OpenAssetIO/OpenAssetIO/issues/1351)
+
 v1.0.0-alpha.9
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,12 @@
 # repository (Python versions, platforms, etc): https://github.com/OpenAssetIO/OpenAssetIO
 
 [build-system]
-requires = [
-    # Pinned to the last version that supports Python 3.7
-    "setuptools==68.*"
-]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-traitgen"
 version = "1.0.0a9"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = ["jinja2==3.1.3", "pyyaml==6.0.0", "jsonschema==4.7.2"]
 
 authors = [
@@ -56,7 +52,7 @@ corresponding python package that can be used for custom generation.
 
 ## Supported languages
 
-- Python 3.7+
+- Python 3.10+
 
 ## Installation
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -303,11 +303,8 @@ class Test_CLI_args:
 
 
 def execute_cli(*args):
-    # Str wrapping prevents issues with Path objects in Windows
-    # Python 3.7
     all_args = ["openassetio-traitgen"]
-    str_args = [str(a) for a in args]
-    all_args.extend(str_args)
+    all_args.extend(args)
     # We explicitly don't want an exception to be raised.
     # pylint: disable=subprocess-run-check
     return subprocess.run(all_args, capture_output=True, encoding="utf-8")


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1351.

Remove support for Python 3.7 and 3.9. Hence remove workarounds for Python 3.7 support.

Use CI runner and Python version that best matches VFX Reference Platform CY24.