### PR TITLE
Default to CY24 and drop support for CY22 and below

### DIFF
--- a/.github/build_openassetio/action.yml
+++ b/.github/build_openassetio/action.yml
@@ -15,7 +15,6 @@ runs:
       with:
         repository: OpenAssetIO/OpenAssetIO
         path: openassetio-checkout
-        ref: v1.0.0-beta.1.0
 
     - name: Build OpenAssetIO
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[CI]"
-    ignore:
-      # TODO(DF): Remove once no longer stuck on ASWF CY22 Docker image
-      # for CI (causing nodejs glibc error).
-      - dependency-name: "actions/checkout"
-        update-types: [ "version-update:semver-major" ]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build_wheels:
     name: Build wheel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Pylint
     steps:
       - uses: actions/checkout@v3
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         # Pin openassetio to match C++ version, since
@@ -39,7 +39,7 @@ jobs:
             tests
 
   black:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Python formatting
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -57,7 +57,7 @@ jobs:
         run: black --diff --check .
 
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,12 +20,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Download wheels from OpenAssetIO main
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - name: Install dependencies
-        # Pin openassetio to match C++ version, since
-        # tests/requirements.txt specifies a range. Also see
-        # build_openassetio action.
         run: |
-          python -m pip install openassetio==1.0.0b1.rev0
+          python -m pip install --find-links ./deps openassetio
           python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
 

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   publish_testpypi:
     name: Publish distribution 📦 to TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v6
@@ -38,7 +38,7 @@ jobs:
   publish_pypi:
     name: Publish distribution 📦 to PyPI
     needs: publish_testpypi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-13']
-        python: ['3.7', '3.9', '3.10']
+        os: ['windows-2022', 'ubuntu-22.04', 'macos-13']
+        python: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -36,7 +36,7 @@ jobs:
 
   build-openassetio:
     name: Build OpenAssetIO
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/openassetio/openassetio-build
     steps:
@@ -46,10 +46,10 @@ jobs:
 
   ctest:
     name: C++ tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-openassetio
     container:
-      image: aswf/ci-vfxall:2022-clang14.3
+      image: aswf/ci-base:2024
     steps:
       - uses: actions/checkout@v3
 
@@ -72,7 +72,7 @@ jobs:
           # Set the PYTHONPATH to the output of build-openassetio
           # Even though we are running C++ tests, pytest still discovers
           # all the python files, so they need to be valid imports.
-          PYTHONPATH: ${{ github.workspace }}/openassetio/lib/python3.9/site-packages
+          PYTHONPATH: ${{ github.workspace }}/openassetio/lib/python3.11/site-packages
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/openassetio
           # TODO(DF): Sanitizers disabled due to lack of support in ASWF
           # Docker image. Re-enable once per-platform builds enabled

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,21 @@ jobs:
         python: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Download wheels from OpenAssetIO main
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      # Pin openassetio to match C++ version, since
-      # tests/requirements.txt specifies a range. Also see
-      # build_openassetio action.
       - run: |
-          python -m pip install openassetio==1.0.0b1.rev0
+          python -m pip install --find-links ./deps openassetio
           python -m pip install -r tests/requirements.txt
           python -m pip install .
       - name: Test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ corresponding python package that can be used for custom generation.
 
 ## Supported languages
 
-- Python 3.7+
+- Python 3.10+
 - C++ 17+
 
 ## Installation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Breaking changes
+
+- Removed support for VFX Reference Platform CY22 or lower and added
+  support for CY24. This means Python 3.7 and 3.9 builds are no longer
+  tested or published, whereas Python 3.11 is now published.
+  [OpenAssetIO#1351](https://github.com/OpenAssetIO/OpenAssetIO/issues/1351)
+
 v1.0.0-alpha.9
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,13 @@
 # repository (Python versions, platforms, etc): https://github.com/OpenAssetIO/OpenAssetIO
 
 [build-system]
-requires = [
-    # Pinned to the last version that supports Python 3.7
-    "setuptools==68.*"
-]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-traitgen"
 version = "1.0.0a9"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = ["jinja2==3.1.4", "pyyaml==6.0.0", "jsonschema==4.7.2"]
 
 authors = [
@@ -56,7 +53,7 @@ corresponding python package that can be used for custom generation.
 
 ## Supported languages
 
-- Python 3.7+
+- Python 3.10+
 
 ## Installation
 

--- a/tests/generators/cpp/CMakeLists.txt
+++ b/tests/generators/cpp/CMakeLists.txt
@@ -14,12 +14,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang
 else ()
     set(IS_GCC_OR_CLANG FALSE)
 endif ()
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
-    set(IS_GCC_GTEQ_5 TRUE)
-else ()
-    set(IS_GCC_GTEQ_5 FALSE)
-endif ()
 
 # Additional include directories for CMake utils.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
@@ -50,14 +44,6 @@ if (IS_GCC_OR_CLANG)
     option(OPENASSETIO_TRAITGENTEST_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
         "Enable undefined behavior sanitizer" OFF)
 endif ()
-
-# Disable C++11 ABI by default, as per current VFX reference
-# platform(s), but allow optionally enabling.
-if (IS_GCC_GTEQ_5)
-    option(OPENASSETIO_TRAITGENTEST_GLIBCXX_USE_CXX11_ABI
-        "For gcc, use the new C++11 library ABI" OFF)
-endif ()
-
 
 #-----------------------------------------------------------------------
 # Target linting and properties
@@ -101,9 +87,6 @@ message(STATUS "Linter: clang-tidy              = ${OPENASSETIO_TRAITGENTEST_ENA
 message(STATUS "Linter: cpplint                 = ${OPENASSETIO_TRAITGENTEST_ENABLE_CPPLINT} [${OPENASSETIO_TRAITGENTEST_CPPLINT_EXE}]")
 message(STATUS "Linter: clang-format            = ${OPENASSETIO_TRAITGENTEST_ENABLE_CLANG_FORMAT} [${OPENASSETIO_TRAITGENTEST_CLANGFORMAT_EXE}]")
 message(STATUS "Linter: cmake-lint              = ${OPENASSETIO_TRAITGENTEST_ENABLE_CMAKE_LINT} [${OPENASSETIO_TRAITGENTEST_CMAKELINT_EXE}]")
-if (IS_GCC_GTEQ_5)
-    message(STATUS "New C++11 ABI for gcc           = ${OPENASSETIO_TRAITGENTEST_GLIBCXX_USE_CXX11_ABI}")
-endif ()
 if (IS_GCC_OR_CLANG)
     message(STATUS "Sanitizer: Address              = ${OPENASSETIO_TRAITGENTEST_ENABLE_SANITIZER_ADDRESS}")
     message(STATUS "Sanitizer: Undefined behavior   = ${OPENASSETIO_TRAITGENTEST_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}")

--- a/tests/generators/cpp/cmake/DefaultTargetProperties.cmake
+++ b/tests/generators/cpp/cmake/DefaultTargetProperties.cmake
@@ -45,15 +45,6 @@ function(openassetio_traitgentest_set_default_target_properties target_name)
         target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL")
     endif ()
 
-    # Whether to use the old or new C++ ABI with gcc.
-    if (IS_GCC_GTEQ_5)
-        if (OPENASSETIO_TRAITGENTEST_GLIBCXX_USE_CXX11_ABI)
-            target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
-        else ()
-            target_compile_definitions(${target_name} PRIVATE _GLIBCXX_USE_CXX11_ABI=0)
-        endif ()
-    endif ()
-
     #-------------------------------------------------------------------
     # Library version
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -303,11 +303,8 @@ class Test_CLI_args:
 
 
 def execute_cli(*args):
-    # Str wrapping prevents issues with Path objects in Windows
-    # Python 3.7
     all_args = ["openassetio-traitgen"]
-    str_args = [str(a) for a in args]
-    all_args.extend(str_args)
+    all_args.extend(args)
     # We explicitly don't want an exception to be raised.
     # pylint: disable=subprocess-run-check
     return subprocess.run(all_args, capture_output=True, encoding="utf-8")


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1351.

Remove support for Python 3.7 and 3.9. Hence remove workarounds for Python 3.7 support.

Use CI runner and Python version that best matches VFX Reference Platform CY24.