### PR TITLE
[Core] Fix bool vs. int detection in Python setters

### DIFF
--- a/python/openassetio_traitgen/templates/python/traits.py.in
+++ b/python/openassetio_traitgen/templates/python/traits.py.in
@@ -80,7 +80,7 @@ class {{ trait.name | to_py_class_name }}Trait:
 
         {{ property.description | wordwrap(64) | indent(8) }}
         """
-        if not isinstance({{ VarName }}, {{ VarType }}):
+        if not type({{ VarName }}) is {{ VarType }}:
             raise TypeError("{{ property.id }} must be a '{{ VarType }}'.")
         self.__data.setTraitProperty(self.kId, "{{ property.id }}", {{ VarName }})
 
@@ -94,7 +94,7 @@ class {{ trait.name | to_py_class_name }}Trait:
         if value is None:
             return defaultValue
 
-        if not isinstance(value, {{ VarType }}):
+        if not type(value) is {{ VarType }}:
             if defaultValue is None:
                 raise TypeError(f"Invalid stored value type: '{type(value).__name__}' should be '{{ VarType }}'.")
             return defaultValue

--- a/tests/generators/test_python.py
+++ b/tests/generators/test_python.py
@@ -434,7 +434,7 @@ class PropertyTestValues(NamedTuple):
 
 kAllPropertiesTrait_property_test_values = (
     PropertyTestValues("boolProperty", True, 123),
-    PropertyTestValues("intProperty", 42, "🐁"),
+    PropertyTestValues("intProperty", 42, False),
     PropertyTestValues("floatProperty", 12.3, False),
     PropertyTestValues("stringProperty", "⛅ outside today", 12),
     # Re-instate once InfoDictionary is supported in TraitsData


### PR DESCRIPTION
Closes #34. Python `int` trait properties could easily be set to `bool` values without realising, since `bool` is a subclass of `int`.

This would probably not cause any problems as long as Python was the only language in use. However, the value would be stored in the underlying C++ `std::variant` as a `bool` value. This means a subsequent C++ trait view class, which was expecting an `int`, would fail to retrieve the value and throw an exception.

So be more strict during the type check when getting or setting trait properties.