### PR TITLE
Use `set` for Python `Specification.kTraitSet` member

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+- Reverted change to `kTraitSet` member of Specification classes
+  from using the `frozenset` type back to using the standard `set`. This
+  is for compatibility with pybind11<2.10.
+  [#94](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen/issues/94)
+
 v1.0.0-alpha.10
 --------------
 

--- a/python/openassetio_traitgen/templates/python/specifications.py.in
+++ b/python/openassetio_traitgen/templates/python/specifications.py.in
@@ -31,7 +31,7 @@ class {{ specification.id | to_py_class_name }}Specification:
     Usage: {{ specification.usage | join(', ') }}
     {% endif -%}
     """
-    kTraitSet = frozenset({
+    kTraitSet = {
         {% for trait in specification.trait_set -%}
         # '{{ trait.id }}'
         {% if trait.package == package.id -%}
@@ -40,7 +40,7 @@ class {{ specification.id | to_py_class_name }}Specification:
         {{ trait.package | to_py_module_name }}.traits.{{ trait.namespace | to_py_module_name }}.{{ trait.name | to_py_class_name }}Trait.kId,
         {% endif -%}
         {% endfor %}
-    })
+    }
 
     def __init__(self, traitsData):
         """

--- a/tests/generators/test_python.py
+++ b/tests/generators/test_python.py
@@ -216,12 +216,6 @@ class Test_python_package_all_specifications_test_TwoLocalTraitsSpecification:
         }
         assert module_all.specifications.test.TwoLocalTraitsSpecification.kTraitSet == expected
 
-        # Ensure we can use the trait set as a dict key, i.e. it is a
-        # `frozenset`.
-        assert {module_all.specifications.test.TwoLocalTraitsSpecification.kTraitSet: True}[
-            module_all.specifications.test.TwoLocalTraitsSpecification.kTraitSet
-        ] is True
-
     def test_has_trait_getters_with_expected_docstring(self, module_all):
         trait_one = module_all.traits.aNamespace.NoPropertiesTrait
         trait_two = module_all.traits.anotherNamespace.NoPropertiesTrait
@@ -266,11 +260,6 @@ class Test_python_package_all_specifications_test_OneExternalTraitSpecification:
             module_traits_only.traits.test.AnotherTrait.kId,
         }
         assert module_all.specifications.test.OneExternalTraitSpecification.kTraitSet == expected
-        # Ensure we can use the trait set as a dict key, i.e. it is a
-        # `frozenset`.
-        assert {module_all.specifications.test.OneExternalTraitSpecification.kTraitSet: True}[
-            module_all.specifications.test.OneExternalTraitSpecification.kTraitSet
-        ] is True
 
     def test_has_trait_getters_with_expected_docstring(self, module_all, module_traits_only):
         trait = module_traits_only.traits.test.AnotherTrait
@@ -305,11 +294,6 @@ class Test_python_package_all_specifications_test_LocalAndExternalTraitSpecifica
         assert (
             module_all.specifications.test.LocalAndExternalTraitSpecification.kTraitSet == expected
         )
-        # Ensure we can use the trait set as a dict key, i.e. it is a
-        # `frozenset`.
-        assert {module_all.specifications.test.LocalAndExternalTraitSpecification.kTraitSet: True}[
-            module_all.specifications.test.LocalAndExternalTraitSpecification.kTraitSet
-        ] is True
 
     def test_has_trait_getters_with_expected_docstring(self, module_all, module_traits_only):
         trait_one = module_all.traits.aNamespace.NoPropertiesTrait


### PR DESCRIPTION
Closes #94. Reverts #55. Revert change for Specification class's `kTraitSet` member to `frozenset`, since this is incompatible with older versions of pybind11.

pybind11 is used internally to manage Python<->C++ bindings in OpenAssetIO. If pybind11 is used in a host application too, the versions must (currently) match.

So support host applications that ship with an older pybind11 by eschewing `frozenset`, for now.

See also OpenAssetIO/OpenAssetIO#1420.