### PR TITLE
[Lint] `black` reformat with latest version

### DIFF
--- a/python/openassetio_traitgen/generators/helpers.py
+++ b/python/openassetio_traitgen/generators/helpers.py
@@ -65,7 +65,7 @@ def default_template_globals() -> dict:
 
 
 def package_dependencies(
-    declarations: List[Union[SpecificationDeclaration, TraitDeclaration]]
+    declarations: List[Union[SpecificationDeclaration, TraitDeclaration]],
 ) -> List[str]:
     """
     Returns a list of all dependent package names for the supplied
@@ -77,7 +77,7 @@ def package_dependencies(
 
 
 def _package_dependencies_for_declaration(
-    declaration: Union[SpecificationDeclaration, TraitDeclaration]
+    declaration: Union[SpecificationDeclaration, TraitDeclaration],
 ) -> List[str]:
     """
     Returns a list of all dependent package names for the supplied


### PR DESCRIPTION
In CI we use the latest version of `black`, and there appears to be a small upstream change to the rules that is causing CI to fail (i.e.

Signed-off-by: David Feltell <david.feltell@foundry.com>
#101).