### PR TITLE
[Core] Add UI usage options to schema

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,19 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Improvements
+
+- Added `ui` and `uiPolicy` options for the `usage` field on traits and
+  specifications.
+  [#103](https://github.com/OpenAssetIO/OpenAssetIO-TraitGen/issues/103)
+
 v1.0.0-alpha.11
 --------------
+
+### Bug fixes
 
 - Reverted change to `kTraitSet` member of Specification classes
   from using the `frozenset` type back to using the standard `set`. This

--- a/python/openassetio_traitgen/schema.json
+++ b/python/openassetio_traitgen/schema.json
@@ -88,7 +88,9 @@
                           "entity",
                           "relationship",
                           "locale",
-                          "managementPolicy"
+                          "managementPolicy",
+                          "ui",
+                          "uiPolicy"
                         ]
                       }
                     }
@@ -175,7 +177,9 @@
                           "entity",
                           "relationship",
                           "locale",
-                          "managementPolicy"
+                          "managementPolicy",
+                          "ui",
+                          "uiPolicy"
                         ]
                       }
                     }


### PR DESCRIPTION
Closes #103.

The design for UI delegation makes use of traits to specify the kind of UI that the host wants the delegate to provide. These will be distinct from other usages of traits and specifically for UI. The design includes a `uiPolicy` introspection method as well as the main `populateUI` method. So we need two new usage types.

So add `ui` and `uiPolicy` usage types for traits and specifications to the YAML schema